### PR TITLE
Feat: Add Status/Stories Integration in Chat

### DIFF
--- a/app.py
+++ b/app.py
@@ -1135,11 +1135,23 @@ def chat_inbox():
 
     active_chats.sort(key=get_sort_key, reverse=True)
 
+    # Get a set of all user IDs involved in the conversations
+    all_participant_ids = {p.user_id for p_entry in user_participant_entries for p in p_entry.conversation.participants}
+
+    # Find which of those users have active stories
+    now = datetime.now(timezone.utc)
+    users_with_stories = db.session.query(Story.user_id).filter(
+        Story.user_id.in_(all_participant_ids),
+        Story.expires_at > now
+    ).distinct().all()
+    user_ids_with_stories = {user_id for user_id, in users_with_stories}
+
     return render_template(
         'chat_inbox.html',
         active_chats=active_chats,
         message_requests=message_requests,
         archived_chats=archived_chats,
+        user_ids_with_stories=user_ids_with_stories,
         Message=Message
     )
 
@@ -1162,6 +1174,24 @@ def discover_modes():
     """Displays all available modes for users to browse."""
     all_modes = Mode.query.order_by(Mode.name).all()
     return render_template('discover_modes.html', modes=all_modes)
+
+@app.route('/stories/user/<int:user_id>')
+@login_required
+def view_user_stories(user_id):
+    now = datetime.now(timezone.utc)
+    # Find the most recent, active story for this user
+    latest_story = Story.query.filter(
+        Story.user_id == user_id,
+        Story.expires_at > now
+    ).order_by(Story.created_at.desc()).first()
+
+    if latest_story:
+        return redirect(url_for('story_viewer', story_id=latest_story.id))
+    else:
+        # If no active story, you might want to redirect to the user's profile
+        # or back to the inbox with a flash message.
+        flash('This user has no active stories.', 'info')
+        return redirect(request.referrer or url_for('home'))
 
 @app.route('/story/<int:story_id>')
 @login_required

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1970,3 +1970,9 @@ body:has(.main-nav) {
 .chat-row.swiping {
     transition: none; /* Disable transition during active swipe for responsiveness */
 }
+
+/* --- Story Indicator in Chat List --- */
+.chat-avatar-container.has-story .chat-avatar {
+    border: 3px solid #0095f6;
+    padding: 2px;
+}

--- a/static/posts/1_1756482823_test.jpg
+++ b/static/posts/1_1756482823_test.jpg
@@ -1,0 +1,1 @@
+this is a fake photo

--- a/static/stories/1_1756482815_test.jpg
+++ b/static/stories/1_1756482815_test.jpg
@@ -1,0 +1,1 @@
+this is a fake image

--- a/templates/chat_inbox.html
+++ b/templates/chat_inbox.html
@@ -61,16 +61,18 @@
                         </div>
 
                         <div class="chat-row swipe-target {% if p_entry.is_pinned %}pinned{% endif %}">
+                            {% set other_participant = convo.participants|rejectattr('user_id', 'equalto', g.user.id)|first %}
+                            {% set avatar_user = other_participant.user if other_participant else g.user %}
+                            <div class="chat-avatar-container {% if avatar_user.id in user_ids_with_stories %}has-story{% endif %}">
+                                <a href="{{ url_for('view_user_stories', user_id=avatar_user.id) }}">
+                                {% if convo.is_group %}
+                                     <img src="{{ url_for('static', filename=convo.group_photo_path or 'img/default_group.png') }}" alt="{{ convo.name }}'s avatar" class="chat-avatar">
+                                {% else %}
+                                    <img src="https://i.pravatar.cc/150?u={{ avatar_user.username }}" alt="{{ avatar_user.username }}'s avatar" class="chat-avatar">
+                                {% endif %}
+                                </a>
+                            </div>
                             <a href="{{ url_for('message_thread', conversation_id=convo.id) }}" class="chat-row-link">
-                                <div class="chat-avatar-container">
-                                    {% set other_participant = convo.participants|rejectattr('user_id', 'equalto', g.user.id)|first %}
-                                    {% if convo.is_group %}
-                                         <img src="{{ url_for('static', filename=convo.group_photo_path or 'img/default_group.png') }}" alt="{{ convo.name }}'s avatar" class="chat-avatar">
-                                    {% elif other_participant %}
-                                        {% set other_user = other_participant.user %}
-                                        <img src="https://i.pravatar.cc/150?u={{ other_user.username }}" alt="{{ other_user.username }}'s avatar" class="chat-avatar">
-                                    {% endif %}
-                                </div>
                                 <div class="chat-details">
                                     <div class="chat-row-top">
                                         <span class="chat-name">

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,6 +1,7 @@
 import pytest
+from datetime import datetime, timezone
 from tests.test_auth import register_user, login
-from app import db, User, Conversation, Message, Participant, socketio
+from app import db, User, Conversation, Message, Participant, socketio, Story
 
 def test_start_new_chat(client):
     """Test starting a new conversation."""
@@ -264,3 +265,44 @@ def test_disappearing_messages(client, app):
     # Verify the message is gone
     response = client.get(f'/chat/{convo.id}')
     assert b'This will disappear' not in response.data
+
+def test_story_indicator_in_chat_inbox(client, app):
+    """Test that a story indicator appears for users with active stories."""
+    from datetime import timedelta
+
+    user1 = register_user(username='user1', email='user1@test.com', password='pw')
+    user2 = register_user(username='user2', email='user2@test.com', password='pw')
+
+    # user2 creates a story
+    story = Story(author=user2, media_path='stories/test.jpg')
+    db.session.add(story)
+
+    # Create a conversation between them
+    convo = Conversation()
+    p1 = Participant(user=user1, conversation=convo)
+    p2 = Participant(user=user2, conversation=convo)
+    db.session.add_all([convo, p1, p2])
+    db.session.commit()
+
+    login(client, 'user1', 'pw')
+    response = client.get('/chat')
+    assert response.status_code == 200
+
+    # Check for the 'has-story' class on the container of user2's avatar
+    expected_html_div = f'<div class="chat-avatar-container has-story">'
+    assert expected_html_div in response.data.decode()
+
+    # Check that the link around the avatar points to the correct story route
+    expected_link = f'<a href="/stories/user/{user2.id}">'
+    assert expected_link in response.data.decode()
+
+    # Test the redirection
+    response = client.get(f'/stories/user/{user2.id}', follow_redirects=False)
+    assert response.status_code == 302
+    assert response.location == f'/story/{story.id}'
+
+    # Test that an expired story does not show the indicator
+    story.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    db.session.commit()
+    response = client.get('/chat')
+    assert expected_html_div not in response.data.decode()


### PR DESCRIPTION
This commit integrates the existing Stories feature into the chat inbox, allowing users to see which of their contacts have active stories.

Key changes include:

- Backend Logic: The `chat_inbox` route has been updated to efficiently query for users with active stories and pass this information to the template.

- New Route: A new user-centric story viewing route (`/stories/user/<id>`) has been added to provide a stable link from the chat inbox to a user's latest story.

- UI: The chat inbox now displays a visual indicator (a colored ring) around the avatar of users with active stories. The avatar is now a link that takes the user to the story viewer.

- Testing: A new test case has been added to verify that the story indicator and link appear correctly and that the redirection works as expected. All tests are passing.