### PR TITLE
Feat: Add @username Mentions in Group Chats

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ import click
 from flask.cli import with_appcontext
 from functools import wraps
 import humanize
+import re
 from flask_socketio import SocketIO, emit, join_room, leave_room
 from flask_migrate import Migrate
 
@@ -640,7 +641,12 @@ def message_thread(conversation_id):
 
     messages = messages_query.all()
     other_user = next((p.user for p in convo.participants if p.user_id != g.user.id), None)
-    return render_template('message_thread.html', conversation=convo, messages=messages, other_user=other_user)
+
+    group_members = []
+    if convo.is_group:
+        group_members = [{'id': p.user.id, 'username': p.user.username, 'full_name': p.user.full_name} for p in convo.participants]
+
+    return render_template('message_thread.html', conversation=convo, messages=messages, other_user=other_user, group_members=group_members)
 
 @app.route('/chat/start/<int:user_id>')
 @login_required
@@ -1444,6 +1450,28 @@ def handle_send_message_event(data):
         'timestamp': new_message.created_at.isoformat()
     }
     emit('new_message', message_data, room=data['room'])
+
+    # Handle mentions in text messages
+    if new_message.content_type == 'text' and new_message.body:
+        mentions = re.findall(r'@(\w+)', new_message.body)
+        if mentions:
+            notified_users = set()
+            for username in set(mentions): # Use set to avoid duplicate notifications for same @mention
+                if username in notified_users:
+                    continue
+
+                mentioned_user = User.query.filter_by(username=username).first()
+                # Ensure user exists, is in the convo, and is not the sender
+                if mentioned_user and mentioned_user.id != user_id and mentioned_user.id in participant_user_ids:
+                    mention_notification = Notification(
+                        recipient_id=mentioned_user.id,
+                        sender_id=user_id,
+                        type='mention',
+                        related_id=new_message.conversation_id # Link to the conversation
+                    )
+                    db.session.add(mention_notification)
+                    notified_users.add(username)
+            db.session.commit()
 
 @socketio.on('react_message')
 def handle_react_message(data):

--- a/static/posts/1_1756493558_test.jpg
+++ b/static/posts/1_1756493558_test.jpg
@@ -1,0 +1,1 @@
+this is a fake photo

--- a/static/posts/1_1756493748_test.jpg
+++ b/static/posts/1_1756493748_test.jpg
@@ -1,0 +1,1 @@
+this is a fake photo

--- a/static/stories/1_1756493550_test.jpg
+++ b/static/stories/1_1756493550_test.jpg
@@ -1,0 +1,1 @@
+this is a fake image

--- a/static/stories/1_1756493740_test.jpg
+++ b/static/stories/1_1756493740_test.jpg
@@ -1,0 +1,1 @@
+this is a fake image

--- a/templates/message_thread.html
+++ b/templates/message_thread.html
@@ -85,12 +85,15 @@
         </div>
     </div>
     {% else %}
-    <div class="message-input-bar">
-        <input type="file" id="file-input" style="display: none;" accept="image/*,application/pdf,application/msword,text/plain">
-        <button class="icon-button attachment-btn"><i class="fas fa-plus"></i></button>
-        <input type="text" id="message-input" class="message-input-field" placeholder="Type a message...">
-        <button class="icon-button mic-btn"><i class="fas fa-microphone"></i></button>
-        <button class="icon-button send-btn" style="display: none;"><i class="fas fa-paper-plane"></i></button>
+    <div class="message-input-container">
+        <div id="mention-suggestions" class="mention-suggestions-popup"></div>
+        <div class="message-input-bar">
+            <input type="file" id="file-input" style="display: none;" accept="image/*,application/pdf,application/msword,text/plain">
+            <button class="icon-button attachment-btn"><i class="fas fa-plus"></i></button>
+            <input type="text" id="message-input" class="message-input-field" placeholder="Type a message...">
+            <button class="icon-button mic-btn"><i class="fas fa-microphone"></i></button>
+            <button class="icon-button send-btn" style="display: none;"><i class="fas fa-paper-plane"></i></button>
+        </div>
     </div>
     {% endif %}
 </div>
@@ -102,6 +105,8 @@
     document.addEventListener('DOMContentLoaded', function() {
         var socket = io.connect(location.protocol + '//' + document.domain + ':' + location.port);
         var conversationId = "{{ conversation.id }}";
+        const isGroupChat = {{ conversation.is_group|tojson }};
+        const groupMembers = {{ group_members|tojson|safe }};
 
         // --- DOM Elements ---
         const messageList = document.getElementById('message-list');
@@ -110,6 +115,7 @@
         const micBtn = document.querySelector('.mic-btn');
         const attachmentBtn = document.querySelector('.attachment-btn');
         const fileInput = document.getElementById('file-input');
+        const mentionPopup = document.getElementById('mention-suggestions');
 
         // --- Functions ---
         function scrollToBottom() {
@@ -124,13 +130,14 @@
             msgContainer.className = `msg-container ${isSent ? 'sent' : 'received'}`;
 
             let senderNameHtml = '';
-            if ({{ conversation.is_group|tojson }} && !isSent) {
+            if (isGroupChat && !isSent) {
                 senderNameHtml = `<span class="sender-name">${msg.author_name || 'User'}</span>`;
             }
 
             let messageContentHtml = '';
             if (msg.content_type === 'text') {
-                messageContentHtml = `<p class="msg-text">${msg.body}</p>`;
+                const highlightedBody = msg.body.replace(/@(\w+)/g, '<strong>@$1</strong>');
+                messageContentHtml = `<p class="msg-text">${highlightedBody}</p>`;
             } else if (msg.content_type === 'image') {
                 const imageUrl = `/static/${msg.file_path}`;
                 messageContentHtml = `<img src="${imageUrl}" alt="User image" class="msg-image">`;
@@ -190,6 +197,37 @@
             }
         }
 
+        function showMentionSuggestions(query) {
+            mentionPopup.innerHTML = '';
+            const filteredMembers = groupMembers.filter(member =>
+                member.username.toLowerCase().startsWith(query.toLowerCase()) ||
+                member.full_name.toLowerCase().startsWith(query.toLowerCase())
+            );
+
+            if(filteredMembers.length === 0) {
+                mentionPopup.style.display = 'none';
+                return;
+            }
+
+            filteredMembers.forEach(member => {
+                const item = document.createElement('div');
+                item.className = 'mention-item';
+                item.textContent = `${member.full_name} (@${member.username})`;
+                item.onclick = () => insertMention(member.username);
+                mentionPopup.appendChild(item);
+            });
+            mentionPopup.style.display = 'block';
+        }
+
+        function insertMention(username) {
+            const currentText = messageInput.value;
+            const atIndex = currentText.lastIndexOf('@');
+            const newText = currentText.substring(0, atIndex) + `@${username} `;
+            messageInput.value = newText;
+            mentionPopup.style.display = 'none';
+            messageInput.focus();
+        }
+
         // --- Socket.IO Event Handlers ---
         socket.on('connect', function() {
             socket.emit('join', {room: conversationId});
@@ -205,13 +243,14 @@
             if (message.trim() !== '') {
                 socket.emit('send_message', {room: conversationId, message: message, content_type: 'text'});
                 messageInput.value = '';
+                mentionPopup.style.display = 'none';
                 messageInput.dispatchEvent(new Event('input'));
             }
         }
 
         sendBtn.addEventListener('click', sendMessage);
         messageInput.addEventListener('keypress', function(e) {
-            if (e.key === 'Enter') {
+            if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
                 sendMessage();
             }
@@ -224,6 +263,17 @@
             } else {
                 micBtn.style.display = 'block';
                 sendBtn.style.display = 'none';
+            }
+
+            const text = messageInput.value;
+            const atIndex = text.lastIndexOf('@');
+            const spaceIndex = text.lastIndexOf(' ');
+
+            if (isGroupChat && atIndex > spaceIndex) {
+                const query = text.substring(atIndex + 1);
+                showMentionSuggestions(query);
+            } else {
+                mentionPopup.style.display = 'none';
             }
         });
 
@@ -243,6 +293,30 @@
     });
 </script>
 <style>
+    .message-input-container {
+        position: relative;
+    }
+    .mention-suggestions-popup {
+        display: none;
+        position: absolute;
+        bottom: 100%;
+        left: 0;
+        right: 0;
+        background: white;
+        border: 1px solid #dbdbdb;
+        border-radius: 8px;
+        box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
+        max-height: 200px;
+        overflow-y: auto;
+        margin-bottom: 5px;
+    }
+    .mention-item {
+        padding: 10px 15px;
+        cursor: pointer;
+    }
+    .mention-item:hover {
+        background-color: #f0f2f5;
+    }
     .msg-image {
         max-width: 100%;
         border-radius: 15px;

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import datetime, timezone
 from tests.test_auth import register_user, login
-from app import db, User, Conversation, Message, Participant, socketio, Story
+from app import db, User, Conversation, Message, Participant, socketio, Story, Notification
 from datetime import date
 
 def test_start_new_chat(client):
@@ -120,6 +120,46 @@ def test_send_and_receive_media_message(app):
 
         c1.disconnect()
         c2.disconnect()
+
+def test_mention_notification(app):
+    """Test that a user receives a notification when mentioned in a group chat."""
+    with app.test_client() as client:
+        # Setup
+        user1 = User(id=1, full_name='User1', username='user1', email='u1@test.com', date_of_birth=date(2000, 1, 1))
+        user1.set_password('pw')
+        user2 = User(id=2, full_name='User2', username='user2', email='u2@test.com', date_of_birth=date(2000, 1, 1))
+        user2.set_password('pw')
+        convo = Conversation(id=1, is_group=True, name="Mention Test Group")
+        p1 = Participant(user=user1, conversation=convo)
+        p2 = Participant(user=user2, conversation=convo)
+        db.session.add_all([user1, user2, convo, p1, p2])
+        db.session.commit()
+
+        # Log in as user1
+        response = client.post('/login', data={'username': 'user1', 'password': 'pw'})
+        cookie = response.headers.get('Set-Cookie').split(';')[0]
+        socketio_client = socketio.test_client(app, headers={'Cookie': cookie})
+        assert socketio_client.is_connected()
+
+        # Send a message mentioning user2
+        message_text = "Hello @user2, how are you?"
+        socketio_client.emit('send_message', {
+            'room': str(convo.id),
+            'message': message_text,
+            'content_type': 'text'
+        })
+
+        # Give a moment for the event to be processed
+        import time
+        time.sleep(0.1)
+
+        # Verify that user2 received a notification
+        notification = Notification.query.filter_by(recipient_id=user2.id, type='mention').first()
+        assert notification is not None
+        assert notification.sender_id == user1.id
+        assert notification.related_id == convo.id
+
+        socketio_client.disconnect()
 
 def test_message_request_flow(client):
     """Test the full message request workflow."""


### PR DESCRIPTION
This commit adds the ability for users to mention each other in group chats using the @username syntax.

Key changes include:

- Backend: The `handle_send_message_event` function now parses outgoing messages for mentions. When a valid user is mentioned, a new `mention` notification is created for them.

- Frontend:
  - The message input component now detects when a user types '@' and displays a suggestions popup with a list of group members.
  - The chat view now highlights mentioned usernames in the message text.

- Testing: A new test has been added to verify that mention notifications are created correctly on the backend.